### PR TITLE
Update points comp datepicker

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -223,7 +223,7 @@
 				"js/cheevos.pointscomp.js"
 			],
 			"dependencies": [
-				"jquery.ui.datepicker",
+				"mediawiki.widgets.DateInputWidget",
 				"ext.hydraCore.pagination.styles"
 			],
 			"position": "top"

--- a/js/cheevos.pointscomp.js
+++ b/js/cheevos.pointscomp.js
@@ -1,30 +1,15 @@
 var setupPointsCompDatepickers = function() {
-	$("input#start_time_datepicker, input#end_time_datepicker").datepicker(
+	var startDate = new mw.widgets.DateInputWidget(
 		{
-			dateFormat: "yy-mm-dd",
-			constrainInput: true,
-			onSelect: function(dateText) {
-				var epochInput = '#'+$(this).attr('data-input');
-				$(epochInput).val(epochDate(this));
-			}
+			inputFormat: 'YYYY-MM-DD',
+			displayFormat: 'YYYY-MM-DD',
+			value: $('#start_time_datepicker').val(),
+			dataInput: $('#start_time_datepicker').attr('data-input')
 		}
 	);
+	$("#start_time_datepicker").replaceWith(startDate.$element);
+	startDate.on('change', function() {
+		$('#'+startDate.dataInput).val(new Date(startDate.getValue()).getTime() / 1000);
+	});
 }
 setupPointsCompDatepickers();
-
-var epochDate = function(dateField) {
-	var time = $(dateField).datepicker("getDate");
-	var offset = time.getTimezoneOffset() * 60;
-	var epoch = time.getTime() / 1000 - offset;
-
-	return epoch;
-}
-
-$('input#start_time, input#end_time').change(function() {
-	var currentVal = $(this).val();
-	if (currentVal > 0) {
-		var existEpochDate = new Date(currentVal * 1000);
-		var picker = '#'+$(this).attr('id')+'_datepicker';
-		$(picker).datepicker("setDate", existEpochDate);
-	}
-}).change();

--- a/js/cheevos.pointscomp.js
+++ b/js/cheevos.pointscomp.js
@@ -7,9 +7,9 @@ var setupPointsCompDatepickers = function() {
 			dataInput: $('#start_time_datepicker').attr('data-input')
 		}
 	);
-	$("#start_time_datepicker").replaceWith(startDate.$element);
+	$('#start_time_datepicker').replaceWith(startDate.$element);
 	startDate.on('change', function() {
-		$('#'+startDate.dataInput).val(new Date(startDate.getValue()).getTime() / 1000);
+		document.getElementById('start_time').value = (new Date(startDate.getValue()).getTime()) / 1000;
 	});
 }
 setupPointsCompDatepickers();


### PR DESCRIPTION
Fixes the setting and submission of a start date on the Special:PointsComp page. jQuery datepicker is no longer supported and should not be used.