### PR TITLE
DPAD-921 Fix collection of revoked edits

### DIFF
--- a/Cheevos.hooks.php
+++ b/Cheevos.hooks.php
@@ -251,6 +251,7 @@ class CheevosHooks {
 		$revertedRev = $revisionStore->getRevisionById($editResult->getNewestRevertedRevisionId());
 		$oldestRevId = $editResult->getOldestRevertedRevisionId();
 		$editsToRevoke = [];
+		// Revoke every edit that was reverted as a result of this rollback
 		while ($revertedRev) {
 			$editsToRevoke[] = $revertedRev->getId();
 			if ($revertedRev->getId() == $oldestRevId) {

--- a/Cheevos.hooks.php
+++ b/Cheevos.hooks.php
@@ -238,7 +238,7 @@ class CheevosHooks {
 		RevisionRecord $revision,
 		EditResult $editResult
 	) {
-		if (!$editResult->isRevert()) {
+		if (!$editResult->isRevert() || $editResult->getRevertMethod() !== EditResult::REVERT_ROLLBACK) {
 			// Not a rollback so we don't care
 			return true;
 		}
@@ -249,9 +249,13 @@ class CheevosHooks {
 
 		$revisionStore = MediaWikiServices::getInstance()->getRevisionStore();
 		$revertedRev = $revisionStore->getRevisionById($editResult->getNewestRevertedRevisionId());
+		$oldestRevId = $editResult->getOldestRevertedRevisionId();
 		$editsToRevoke = [];
-		while ($revertedRev && $revertedRev->getId() != $revision->getId()) {
+		while ($revertedRev) {
 			$editsToRevoke[] = $revertedRev->getId();
+			if ($revertedRev->getId() == $oldestRevId) {
+				break;
+			}
 			$revertedRev = $revisionStore->getRevisionById($revertedRev->getParentId());
 		}
 


### PR DESCRIPTION
Fix excess revocation of wiki points during article reverts. This was caused by collecting an incorrect list of revisions from which the points were revoked -- points were being revoked for all of a user's edits on an article, rather than just for the revisions that were reverted.