### PR TITLE
SpecialWikiPoints: Fix optional parameter before required one

### DIFF
--- a/src/Specials/SpecialWikiPoints.php
+++ b/src/Specials/SpecialWikiPoints.php
@@ -44,7 +44,7 @@ class SpecialWikiPoints extends SpecialPage {
 		$this->wikiPoints( $subPage, $output, $this->getRequest() );
 	}
 
-	public function wikiPoints( ?string $subPage = null, OutputPage $output, WebRequest $request ): void {
+	public function wikiPoints( ?string $subPage, OutputPage $output, WebRequest $request ): void {
 		$username = $request->getVal( 'user' );
 		$error = null;
 		$globalId = null;


### PR DESCRIPTION
This is deprecated (the parameter is implicitly treated as required) and raises warnings on PHP 8.2.