### PR TITLE
Defer all stat increments to a job

### DIFF
--- a/ServiceWiring.php
+++ b/ServiceWiring.php
@@ -46,10 +46,10 @@ return [
 
 	CheevosHelper::class => static function ( MediaWikiServices $services ): CheevosHelper {
 		return new CheevosHelper(
-			$services->getService( AchievementService::class ),
 			$services->getMainConfig(),
 			$services->getService( GlobalTitleLookup::class ),
-			$services->getService( WikiConfigDataService::class )
+			$services->getService( WikiConfigDataService::class ),
+			$services->getJobQueueGroup()
 		);
 	},
 ];

--- a/src/CheevosHelper.php
+++ b/src/CheevosHelper.php
@@ -17,6 +17,7 @@ use Config;
 use Exception;
 use Fandom\Includes\Article\GlobalTitleLookup;
 use Fandom\WikiConfig\WikiVariablesDataService;
+use JobQueueGroup;
 use MediaWiki\Linker\LinkTarget;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserIdentity;
@@ -31,10 +32,10 @@ class CheevosHelper {
 	private static bool $shutdownRan = false;
 
 	public function __construct(
-		private AchievementService $achievementService,
 		private Config $config,
 		private GlobalTitleLookup $globalTitleLookup,
-		private WikiConfigDataService $wikiConfigDataService
+		private WikiConfigDataService $wikiConfigDataService,
+		private JobQueueGroup $jobQueueGroup
 	) {
 	}
 
@@ -72,29 +73,15 @@ class CheevosHelper {
 	}
 
 	private function doIncrements() {
-		// Attempt to do it NOW. If we get an error, fall back to the SyncService job.
-		try {
-			self::$shutdownRan = true;
-			foreach ( self::$increments as $userId => $increment ) {
-				$return = $this->achievementService->increment( $increment );
-				unset( self::$increments[$userId] );
-				if ( isset( $return['earned'] ) ) {
-					foreach ( $return['earned'] as $achievement ) {
-						$achievement = new CheevosAchievement( $achievement );
-						$this->achievementService->broadcastAchievement(
-							$achievement,
-							$increment['site_key'],
-							$increment['user_id']
-						);
-					}
-				}
-			}
-		} catch ( CheevosException $e ) {
-			foreach ( self::$increments as $userId => $increment ) {
-				CheevosIncrementJob::queue( $increment );
-				unset( self::$increments[$userId] );
-			}
+		self::$shutdownRan = true;
+
+		$jobs = [];
+		foreach ( self::$increments as $userId => $increment ) {
+			$jobs[] = CheevosIncrementJob::newSpecification( $increment );
+			unset( self::$increments[$userId] );
 		}
+
+		$this->jobQueueGroup->push( $jobs );
 	}
 
 	public function getUrlOnCheevosCentralWiki( LinkTarget $target ): string {

--- a/src/CheevosHelper.php
+++ b/src/CheevosHelper.php
@@ -17,7 +17,6 @@ use Config;
 use Exception;
 use Fandom\Includes\Article\GlobalTitleLookup;
 use Fandom\WikiConfig\WikiVariablesDataService;
-use JobQueueGroup;
 use Fandom\WikiDomain\WikiConfigData;
 use Fandom\WikiDomain\WikiConfigDataService;
 use MediaWiki\Linker\LinkTarget;

--- a/src/Job/CheevosIncrementJob.php
+++ b/src/Job/CheevosIncrementJob.php
@@ -14,15 +14,16 @@ namespace Cheevos\Job;
 
 use Cheevos\AchievementService;
 use Cheevos\CheevosAchievement;
+use IJobSpecification;
 use Job;
+use JobSpecification;
 use MediaWiki\MediaWikiServices;
 
 class CheevosIncrementJob extends Job {
 	private const COMMAND = 'Cheevos\Job\CheevosIncrementJob';
 
-	public static function queue( array $parameters = [] ): void {
-		$job = new self( self::COMMAND, $parameters );
-		MediaWikiServices::getInstance()->getJobQueueGroup()->push( $job );
+	public static function newSpecification( array $increment ): IJobSpecification {
+		return new JobSpecification( self::COMMAND, $increment );
 	}
 
 	/** @inheritDoc */


### PR DESCRIPTION
Cheevos currently attempts to perform all stat increments in a shutdown function, enqueueing a job if this fails. This can result in excessive load on the backing service as some stats are updated on e.g. every registered user PV on GP wikis, which can in turn also overload the UCP process pool due to the synchronous update.

So, always defer these stat increments to a job instead, for better concurrency control and reduced impact on user-facing process pools.