### PR TITLE
CTOOLS-2355 (fix): Fix HTML escaping to prevent XSS

### DIFF
--- a/src/CheevosHooks.php
+++ b/src/CheevosHooks.php
@@ -391,7 +391,7 @@ class CheevosHooks implements
 
 		return $this->linkRenderer->makeKnownLink(
 			SpecialPage::getTitleFor( 'WikiPointsAdmin' ),
-			wfMessage( 'sp_contributions_wikipoints_admin' )->escaped(),
+			wfMessage( 'sp_contributions_wikipoints_admin' )->text(),
 			[ 'class' => 'mw-usertoollinks-wikipointsadmin' ],
 			[ 'action' => 'lookup', 'user' => $username ]
 		);

--- a/src/Specials/SpecialManageAchievements.php
+++ b/src/Specials/SpecialManageAchievements.php
@@ -476,7 +476,7 @@ class SpecialManageAchievements extends SpecialPage {
 	if ( empty( $username ) ) {
 		$errors[] = [
 			'username' => $username,
-			'message' => $this->msg( 'error_award_bad_user' )->text()
+			'message' => $this->msg( 'error_award_bad_user' )->escaped()
 		];
 	}
 
@@ -485,22 +485,22 @@ class SpecialManageAchievements extends SpecialPage {
 	if ( !$achievement ) {
 		$errors[] = [
 			'username' => $username,
-			'message' => $this->msg( 'error_award_bad_achievement' )->text()
+			'message' => $this->msg( 'error_award_bad_achievement' )->escaped()
 		];
 	}
 
-		$save = [ 'username' => $username, 'achievement_id' => $achievementId ];
-		if ( count( $errors ) ) {
-			return [ 'save' => $save, 'errors' => $errors, 'success' => false ];
-		}
+	$save = [ 'username' => $username, 'achievement_id' => $achievementId ];
+	if ( count( $errors ) ) {
+		return [ 'save' => $save, 'errors' => $errors, 'success' => false ];
+	}
 
-		$awarded = [];
+	$awarded = [];
 	foreach ( explode( ',', $username ) as $getUser ) {
 		$userIdentity = $this->userIdentityLookup->getUserIdentityByName( trim( $getUser ) );
 		if ( !$userIdentity || !$userIdentity->isRegistered() ) {
 			$errors[] = [
 				'username' => $getUser,
-				'message' => $this->msg( 'error_award_bad_user' )->text()
+				'message' => $this->msg( 'error_award_bad_user' )->escaped()
 			];
 			continue;
 		}

--- a/src/Specials/SpecialManageAchievements.php
+++ b/src/Specials/SpecialManageAchievements.php
@@ -456,8 +456,8 @@ class SpecialManageAchievements extends SpecialPage {
 
 		$output->setPageTitle( $this->msg( 'awardachievement' )->escaped() );
 		// Phan can't track escaping through complex array structures passed to templates.
-		//// The template properly escapes all user input with htmlspecialchars().
-		/// // @phan-suppress-next-line SecurityCheck-XSS
+		// The template properly escapes all user input with htmlspecialchars().
+		// @phan-suppress-next-line SecurityCheck-XSS, SecurityCheck-DoubleEscaped
 		$output->addHTML( $this->template->awardForm( $return, $allAchievements ) );
 	}
 
@@ -479,7 +479,7 @@ class SpecialManageAchievements extends SpecialPage {
 		if ( empty( $username ) ) {
 			$errors[] = [
 				'username' => $username,
-				'message' => $this->msg( 'error_award_bad_user' )->escaped()
+				'message' => $this->msg( 'error_award_bad_user' )->text()
 			];
 		}
 
@@ -488,7 +488,7 @@ class SpecialManageAchievements extends SpecialPage {
 		if ( !$achievement ) {
 			$errors[] = [
 				'username' => $username,
-				'message' => $this->msg( 'error_award_bad_achievement' )->escaped()
+				'message' => $this->msg( 'error_award_bad_achievement' )->text()
 			];
 		}
 
@@ -503,7 +503,7 @@ class SpecialManageAchievements extends SpecialPage {
 			if ( !$userIdentity || !$userIdentity->isRegistered() ) {
 				$errors[] = [
 					'username' => $getUser,
-					'message' => $this->msg( 'error_award_bad_user' )->escaped()
+					'message' => $this->msg( 'error_award_bad_user' )->text()
 				];
 				continue;
 			}

--- a/src/Specials/SpecialManageAchievements.php
+++ b/src/Specials/SpecialManageAchievements.php
@@ -476,7 +476,7 @@ class SpecialManageAchievements extends SpecialPage {
 	if ( empty( $username ) ) {
 		$errors[] = [
 			'username' => $username,
-			'message' => $this->msg( 'error_award_bad_user' )->escaped()
+			'message' => $this->msg( 'error_award_bad_user' )->plain()
 		];
 	}
 
@@ -485,7 +485,7 @@ class SpecialManageAchievements extends SpecialPage {
 	if ( !$achievement ) {
 		$errors[] = [
 			'username' => $username,
-			'message' => $this->msg( 'error_award_bad_achievement' )->escaped()
+			'message' => $this->msg( 'error_award_bad_achievement' )->plain()
 		];
 	}
 
@@ -500,7 +500,7 @@ class SpecialManageAchievements extends SpecialPage {
 		if ( !$userIdentity || !$userIdentity->isRegistered() ) {
 			$errors[] = [
 				'username' => $getUser,
-				'message' => $this->msg( 'error_award_bad_user' )->escaped()
+				'message' => $this->msg( 'error_award_bad_user' )->plain()
 			];
 			continue;
 		}

--- a/src/Specials/SpecialManageAchievements.php
+++ b/src/Specials/SpecialManageAchievements.php
@@ -457,7 +457,7 @@ class SpecialManageAchievements extends SpecialPage {
 		$output->setPageTitle( $this->msg( 'awardachievement' )->escaped() );
 		// Phan can't track escaping through complex array structures passed to templates.
 		// The template properly escapes all user input with htmlspecialchars().
-		// @phan-suppress-next-line SecurityCheck-XSS, SecurityCheck-DoubleEscaped
+		// @phan-suppress-next-line SecurityCheck-XSS
 		$output->addHTML( $this->template->awardForm( $return, $allAchievements ) );
 	}
 

--- a/src/Specials/SpecialManageAchievements.php
+++ b/src/Specials/SpecialManageAchievements.php
@@ -472,38 +472,38 @@ class SpecialManageAchievements extends SpecialPage {
 		}
 
 		$errors = [];
-	$username = $request->getVal( 'username' );
-	if ( empty( $username ) ) {
-		$errors[] = [
-			'username' => $username,
-			'message_key' => 'error_award_bad_user'
-		];
-	}
-
-	$achievementId = $request->getInt( 'achievement_id' );
-	$achievement = $this->achievementService->getAchievement( $achievementId );
-	if ( !$achievement ) {
-		$errors[] = [
-			'username' => $username,
-			'message_key' => 'error_award_bad_achievement'
-		];
-	}
-
-	$save = [ 'username' => $username, 'achievement_id' => $achievementId ];
-	if ( count( $errors ) ) {
-		return [ 'save' => $save, 'errors' => $errors, 'success' => false ];
-	}
-
-	$awarded = [];
-	foreach ( explode( ',', $username ) as $getUser ) {
-		$userIdentity = $this->userIdentityLookup->getUserIdentityByName( trim( $getUser ) );
-		if ( !$userIdentity || !$userIdentity->isRegistered() ) {
+		$username = $request->getVal( 'username' );
+		if ( empty( $username ) ) {
 			$errors[] = [
-				'username' => $getUser,
-				'message_key' => 'error_award_bad_user'
+				'username' => $username,
+				'message' => $this->msg( 'error_award_bad_user' )->escaped()
 			];
-			continue;
 		}
+
+		$achievementId = $request->getInt( 'achievement_id' );
+		$achievement = $this->achievementService->getAchievement( $achievementId );
+		if ( !$achievement ) {
+			$errors[] = [
+				'username' => $username,
+				'message' => $this->msg( 'error_award_bad_achievement' )->escaped()
+			];
+		}
+
+		$save = [ 'username' => $username, 'achievement_id' => $achievementId ];
+		if ( count( $errors ) ) {
+			return [ 'save' => $save, 'errors' => $errors, 'success' => false ];
+		}
+
+		$awarded = [];
+		foreach ( explode( ',', $username ) as $getUser ) {
+			$userIdentity = $this->userIdentityLookup->getUserIdentityByName( trim( $getUser ) );
+			if ( !$userIdentity || !$userIdentity->isRegistered() ) {
+				$errors[] = [
+					'username' => $getUser,
+					'message' => $this->msg( 'error_award_bad_user' )->escaped()
+				];
+				continue;
+			}
 
 			$globalId = $userIdentity->getId();
 			$award = [];
@@ -561,7 +561,7 @@ class SpecialManageAchievements extends SpecialPage {
 
 			$award['username'] = $userIdentity->getName();
 			$awarded[] = $award;
-	}
+		}
 
 		return [ 'save' => $save, 'errors' => $errors, 'success' => $awarded ];
 	}

--- a/src/Specials/SpecialManageAchievements.php
+++ b/src/Specials/SpecialManageAchievements.php
@@ -472,22 +472,22 @@ class SpecialManageAchievements extends SpecialPage {
 		}
 
 		$errors = [];
-		$username = $request->getVal( 'username' );
-		if ( empty( $username ) ) {
-			$errors[] = [
-				'username' => $username,
-				'message' => $this->msg( 'error_award_bad_user' )->escaped()
-			];
-		}
+	$username = $request->getVal( 'username' );
+	if ( empty( $username ) ) {
+		$errors[] = [
+			'username' => $username,
+			'message' => $this->msg( 'error_award_bad_user' )->text()
+		];
+	}
 
-		$achievementId = $request->getInt( 'achievement_id' );
-		$achievement = $this->achievementService->getAchievement( $achievementId );
-		if ( !$achievement ) {
-			$errors[] = [
-				'username' => $username,
-				'message' => $this->msg( 'error_award_bad_achievement' )->escaped()
-			];
-		}
+	$achievementId = $request->getInt( 'achievement_id' );
+	$achievement = $this->achievementService->getAchievement( $achievementId );
+	if ( !$achievement ) {
+		$errors[] = [
+			'username' => $username,
+			'message' => $this->msg( 'error_award_bad_achievement' )->text()
+		];
+	}
 
 		$save = [ 'username' => $username, 'achievement_id' => $achievementId ];
 		if ( count( $errors ) ) {
@@ -495,15 +495,15 @@ class SpecialManageAchievements extends SpecialPage {
 		}
 
 		$awarded = [];
-		foreach ( explode( ',', $username ) as $getUser ) {
-			$userIdentity = $this->userIdentityLookup->getUserIdentityByName( trim( $getUser ) );
-			if ( !$userIdentity || !$userIdentity->isRegistered() ) {
-				$errors[] = [
-					'username' => $getUser,
-					'message' => $this->msg( 'error_award_bad_user' )->escaped()
-				];
-				continue;
-			}
+	foreach ( explode( ',', $username ) as $getUser ) {
+		$userIdentity = $this->userIdentityLookup->getUserIdentityByName( trim( $getUser ) );
+		if ( !$userIdentity || !$userIdentity->isRegistered() ) {
+			$errors[] = [
+				'username' => $getUser,
+				'message' => $this->msg( 'error_award_bad_user' )->text()
+			];
+			continue;
+		}
 
 			$globalId = $userIdentity->getId();
 			$award = [];
@@ -561,7 +561,7 @@ class SpecialManageAchievements extends SpecialPage {
 
 			$award['username'] = $userIdentity->getName();
 			$awarded[] = $award;
-		}
+	}
 
 		return [ 'save' => $save, 'errors' => $errors, 'success' => $awarded ];
 	}

--- a/src/Specials/SpecialManageAchievements.php
+++ b/src/Specials/SpecialManageAchievements.php
@@ -455,6 +455,9 @@ class SpecialManageAchievements extends SpecialPage {
 		);
 
 		$output->setPageTitle( $this->msg( 'awardachievement' )->escaped() );
+		// Phan can't track escaping through complex array structures passed to templates.
+		//// The template properly escapes all user input with htmlspecialchars().
+		/// // @phan-suppress-next-line SecurityCheck-XSS
 		$output->addHTML( $this->template->awardForm( $return, $allAchievements ) );
 	}
 

--- a/src/Specials/SpecialManageAchievements.php
+++ b/src/Specials/SpecialManageAchievements.php
@@ -476,7 +476,7 @@ class SpecialManageAchievements extends SpecialPage {
 	if ( empty( $username ) ) {
 		$errors[] = [
 			'username' => $username,
-			'message' => $this->msg( 'error_award_bad_user' )->plain()
+			'message_key' => 'error_award_bad_user'
 		];
 	}
 
@@ -485,7 +485,7 @@ class SpecialManageAchievements extends SpecialPage {
 	if ( !$achievement ) {
 		$errors[] = [
 			'username' => $username,
-			'message' => $this->msg( 'error_award_bad_achievement' )->plain()
+			'message_key' => 'error_award_bad_achievement'
 		];
 	}
 
@@ -500,7 +500,7 @@ class SpecialManageAchievements extends SpecialPage {
 		if ( !$userIdentity || !$userIdentity->isRegistered() ) {
 			$errors[] = [
 				'username' => $getUser,
-				'message' => $this->msg( 'error_award_bad_user' )->plain()
+				'message_key' => 'error_award_bad_user'
 			];
 			continue;
 		}

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -496,37 +496,41 @@ class TemplateManageAchievements {
 		$awardUrl = SpecialPage::getSafeTitleFor( 'ManageAchievements', 'award' )->getFullURL();
 
 		$HTML = '';
-		$wasAwarded = $request->getVal( 'do' ) === 'award';
-		if ( isset( $form['success'] ) && is_array( $form['success'] ) ) {
-			foreach ( $form['success'] as $s ) {
-				if ( $s['message'] == "success" ) {
-					$HTML .= "<div class='successbox'>" .
-							 wfMessage(
-								 'achievement_awarded_to',
-								 $s['username'],
-								 $wasAwarded ? wfMessage( 'awarded' ) : wfMessage( 'unawarded' )
-							 )->escaped() . "</div><br />";
-				}
-				if ( $s['message'] == "nochange" ) {
-					$HTML .= "<div class='successbox'>" .
-							 wfMessage(
-								 'achievement_nochange_to',
-								 $s['username'],
-								 $wasAwarded ? wfMessage( 'awarded' ) : wfMessage( 'unawarded' )
-							 )->escaped() . "</div><br />";
-				}
+	$wasAwarded = $request->getVal( 'do' ) === 'award';
+	if ( isset( $form['success'] ) && is_array( $form['success'] ) ) {
+		foreach ( $form['success'] as $s ) {
+			if ( $s['message'] == "success" ) {
+				$HTML .= "<div class='successbox'>" .
+						 wfMessage(
+							 'achievement_awarded_to',
+							 htmlspecialchars( $s['username'], ENT_QUOTES ),
+							 $wasAwarded ? wfMessage( 'awarded' )->text() : wfMessage( 'unawarded' )->text()
+						 )->text() . "</div><br />";
 			}
-			if ( isset( $form['errors'] ) ) {
-				foreach ( $form['errors'] as $e ) {
-					$HTML .= "<div class='errorbox'>" . $e['username'] . ": " . $e['message'] . "</div><br />";
-				}
+			if ( $s['message'] == "nochange" ) {
+				$HTML .= "<div class='successbox'>" .
+						 wfMessage(
+							 'achievement_nochange_to',
+							 htmlspecialchars( $s['username'], ENT_QUOTES ),
+							 $wasAwarded ? wfMessage( 'awarded' )->text() : wfMessage( 'unawarded' )->text()
+						 )->text() . "</div><br />";
 			}
-		} elseif ( $form['success'] !== null ) {
-			if ( isset( $form['errors'] ) ) {
-				foreach ( $form['errors'] as $e ) {
-					$HTML .= "<div class='errorbox'>" . $e['username'] . ": " . $e['message'] . "</div><br />";
-				}
-			} else {
+		}
+		if ( isset( $form['errors'] ) ) {
+			foreach ( $form['errors'] as $e ) {
+				$HTML .= "<div class='errorbox'>" .
+					htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
+					htmlspecialchars( $e['message'], ENT_QUOTES ) . "</div><br />";
+			}
+		}
+	} elseif ( $form['success'] !== null ) {
+		if ( isset( $form['errors'] ) ) {
+			foreach ( $form['errors'] as $e ) {
+				$HTML .= "<div class='errorbox'>" .
+					htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
+					htmlspecialchars( $e['message'], ENT_QUOTES ) . "</div><br />";
+			}
+		} else {
 				$HTML .= "<div class='errorbox'>" .
 						 wfMessage(
 							 'achievement_award_failed',
@@ -541,25 +545,26 @@ class TemplateManageAchievements {
 						 )->escaped() . "
 					<br />" . $form['success']['message'] . "
 					</div>";
-			}
 		}
+	}
 
 		$HTML .= "
 		<form action='$awardUrl' id='mw-awardachievement-form' method='post' name='mw-awardachievement-form'>
 			<fieldset>
-				<legend>" . wfMessage( 'award_hint' )->escaped() . "</legend>";
-		if ( isset( $form['errors']['username'] ) ) {
-			foreach ( $form['errors']['username'] as $err ) {
-				$HTML .= '<span class="error">' . $err . '</span><br/>';
-			}
+		<legend>" . wfMessage( 'award_hint' )->escaped() . "</legend>";
+	if ( isset( $form['errors']['username'] ) ) {
+		foreach ( $form['errors']['username'] as $err ) {
+			$HTML .= '<span class="error">' . htmlspecialchars( $err, ENT_QUOTES ) . '</span><br/>';
 		}
-				$HTML .= "<label for='offset'>" . wfMessage( 'local_username' )->escaped() . "</label>
-				<textarea
-					id='username_list'
-					name='username'
-					placeholder='Single username, or comma delimited list of usernames.'>" .
-					( isset( $form['save']['username'] ) ?? '' ) . "</textarea>";
-		if ( is_array( $achievements ) && count( $achievements ) ) {
+	}
+		$HTML .= "<label for='offset'>" . wfMessage( 'local_username' )->escaped() . "</label>
+			<textarea
+				id='username_list'
+				name='username'
+				placeholder='Single username, or comma delimited list of usernames.'>" .
+					( isset( $form['save']['username'] ) ?
+						htmlspecialchars( $form['save']['username'], ENT_QUOTES ) : '' ) . "</textarea>";
+	if ( is_array( $achievements ) && count( $achievements ) ) {
 			$HTML .= "
 				" . (
 					isset( $form['errors']['achievement_id'] ) ?
@@ -575,7 +580,7 @@ class TemplateManageAchievements {
 			}
 			$HTML .= "
 				</select><br/>";
-		}
+	}
 		$HTML .= "
 				<input name='type' type='hidden' value='local'/>
 				<button name='do' type='submit' value='award'>" .

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -520,17 +520,25 @@ class TemplateManageAchievements {
 		}
 		if ( isset( $form['errors'] ) ) {
 			foreach ( $form['errors'] as $e ) {
+				// Look up message from key to avoid taint propagation
+				$messageText = isset( $e['message_key'] ) ?
+					wfMessage( $e['message_key'] )->escaped() :
+					htmlspecialchars( $e['message'] ?? '', ENT_QUOTES );
 				$HTML .= "<div class='errorbox'>" .
 					htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
-					htmlspecialchars( $e['message'], ENT_QUOTES ) . "</div><br />";
+					$messageText . "</div><br />";
 			}
 		}
 	} elseif ( $form['success'] !== null ) {
 		if ( isset( $form['errors'] ) ) {
 			foreach ( $form['errors'] as $e ) {
+				// Look up message from key to avoid taint propagation
+				$messageText = isset( $e['message_key'] ) ?
+					wfMessage( $e['message_key'] )->escaped() :
+					htmlspecialchars( $e['message'] ?? '', ENT_QUOTES );
 				$HTML .= "<div class='errorbox'>" .
 					htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
-					htmlspecialchars( $e['message'], ENT_QUOTES ) . "</div><br />";
+					$messageText . "</div><br />";
 			}
 		} else {
 			$msgKey = $wasAwarded ? 'awarded' : 'unawarded';

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -498,7 +498,7 @@ class TemplateManageAchievements {
 					$HTML .= "<div class='successbox'>" .
 							 wfMessage(
 								 'achievement_awarded_to',
-								 $s['username'],
+								 htmlspecialchars( $s['username'], ENT_QUOTES ),
 								 $wasAwarded ? wfMessage( 'awarded' ) : wfMessage( 'unawarded' )
 							 )->escaped() . "</div><br />";
 				}
@@ -506,20 +506,24 @@ class TemplateManageAchievements {
 					$HTML .= "<div class='successbox'>" .
 							 wfMessage(
 								 'achievement_nochange_to',
-								 $s['username'],
+								 htmlspecialchars( $s['username'], ENT_QUOTES ),
 								 $wasAwarded ? wfMessage( 'awarded' ) : wfMessage( 'unawarded' )
 							 )->escaped() . "</div><br />";
 				}
 			}
 			if ( isset( $form['errors'] ) ) {
 				foreach ( $form['errors'] as $e ) {
-					$HTML .= "<div class='errorbox'>" . $e['username'] . ": " . $e['message'] . "</div><br />";
+					$HTML .= "<div class='errorbox'>" .
+						htmlspecialchars( $e['username'] ?? '', ENT_QUOTES ) . ": " .
+						htmlspecialchars( $e['message'] ?? '', ENT_QUOTES ) . "</div><br />";
 				}
 			}
 		} elseif ( $form['success'] !== null ) {
 			if ( isset( $form['errors'] ) ) {
 				foreach ( $form['errors'] as $e ) {
-					$HTML .= "<div class='errorbox'>" . $e['username'] . ": " . $e['message'] . "</div><br />";
+					$HTML .= "<div class='errorbox'>" .
+						htmlspecialchars( $e['username'] ?? '', ENT_QUOTES ) . ": " .
+						htmlspecialchars( $e['message'] ?? '', ENT_QUOTES ) . "</div><br />";
 				}
 			} else {
 				$HTML .= "<div class='errorbox'>" .
@@ -534,7 +538,7 @@ class TemplateManageAchievements {
 								 'UTF-8'
 							 )
 						 )->escaped() . "
-					<br />" . $form['success']['message'] . "
+					<br />" . htmlspecialchars( $form['success']['message'] ?? '', ENT_QUOTES ) . "
 					</div>";
 			}
 		}
@@ -545,7 +549,7 @@ class TemplateManageAchievements {
 				<legend>" . wfMessage( 'award_hint' )->escaped() . "</legend>";
 		if ( isset( $form['errors']['username'] ) ) {
 			foreach ( $form['errors']['username'] as $err ) {
-				$HTML .= '<span class="error">' . $err . '</span><br/>';
+				$HTML .= '<span class="error">' . htmlspecialchars( $err, ENT_QUOTES ) . '</span><br/>';
 			}
 		}
 				$HTML .= "<label for='offset'>" . wfMessage( 'local_username' )->escaped() . "</label>
@@ -553,7 +557,7 @@ class TemplateManageAchievements {
 					id='username_list'
 					name='username'
 					placeholder='Single username, or comma delimited list of usernames.'>" .
-						 ( isset( $form['save']['username'] ) ? $form['save']['username'] : '' ) . "</textarea>";
+					htmlspecialchars( $form['save']['username'] ?? '', ENT_QUOTES ) . "</textarea>";
 		if ( is_array( $achievements ) && count( $achievements ) ) {
 			$HTML .= "
 				" . (

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -500,20 +500,20 @@ class TemplateManageAchievements {
 	if ( isset( $form['success'] ) && is_array( $form['success'] ) ) {
 		foreach ( $form['success'] as $s ) {
 			if ( $s['message'] == "success" ) {
+				// Manually build message with escaped username to avoid taint propagation
+				$msgKey = $wasAwarded ? 'awarded' : 'unawarded';
 				$HTML .= "<div class='successbox'>" .
-						 wfMessage(
-							 'achievement_awarded_to',
-							 htmlspecialchars( $s['username'], ENT_QUOTES ),
-							 $wasAwarded ? wfMessage( 'awarded' )->text() : wfMessage( 'unawarded' )->text()
-						 )->text() . "</div><br />";
+						 htmlspecialchars( $s['username'], ENT_QUOTES ) . " " .
+						 wfMessage( 'achievement_awarded_to_suffix', wfMessage( $msgKey )->text() )->parse() .
+						 "</div><br />";
 			}
 			if ( $s['message'] == "nochange" ) {
+				// Manually build message with escaped username to avoid taint propagation
+				$msgKey = $wasAwarded ? 'awarded' : 'unawarded';
 				$HTML .= "<div class='successbox'>" .
-						 wfMessage(
-							 'achievement_nochange_to',
-							 htmlspecialchars( $s['username'], ENT_QUOTES ),
-							 $wasAwarded ? wfMessage( 'awarded' )->text() : wfMessage( 'unawarded' )->text()
-						 )->text() . "</div><br />";
+						 htmlspecialchars( $s['username'], ENT_QUOTES ) . " " .
+						 wfMessage( 'achievement_nochange_to_suffix', wfMessage( $msgKey )->text() )->parse() .
+						 "</div><br />";
 			}
 		}
 		if ( isset( $form['errors'] ) ) {
@@ -531,20 +531,15 @@ class TemplateManageAchievements {
 					htmlspecialchars( $e['message'], ENT_QUOTES ) . "</div><br />";
 			}
 		} else {
-				$HTML .= "<div class='errorbox'>" .
-						 wfMessage(
-							 'achievement_award_failed',
-							 mb_strtolower(
-								 $wasAwarded ? wfMessage( 'awarded' )->text() : wfMessage( 'unawarded' )->text(),
-								 'UTF-8'
-							 ),
-							 mb_strtolower(
-								 $wasAwarded ? wfMessage( 'awarded' )->text() : wfMessage( 'unawarded' )->text(),
-								 'UTF-8'
-							 )
-						 )->text() . "
-					<br />" . htmlspecialchars( $form['success']['message'], ENT_QUOTES ) . "
-					</div>";
+			$msgKey = $wasAwarded ? 'awarded' : 'unawarded';
+			$HTML .= "<div class='errorbox'>" .
+					 wfMessage(
+						 'achievement_award_failed',
+						 mb_strtolower( wfMessage( $msgKey )->text(), 'UTF-8' ),
+						 mb_strtolower( wfMessage( $msgKey )->text(), 'UTF-8' )
+					 )->parse() . "
+				<br />" . htmlspecialchars( $form['success']['message'], ENT_QUOTES ) . "
+				</div>";
 		}
 	}
 

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -16,7 +16,7 @@ use Cheevos\CheevosAchievement;
 use Cheevos\CheevosHelper;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Context\RequestContext;
-use SpecialPage;
+use MediaWiki\SpecialPage\SpecialPage;
 
 class TemplateManageAchievements {
 	/**

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -518,21 +518,21 @@ class TemplateManageAchievements {
 						 "</div><br />";
 			}
 		}
-		if ( isset( $form['errors'] ) ) {
-			foreach ( $form['errors'] as $e ) {
-				$HTML .= "<div class='errorbox'>" .
-					htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
-					htmlspecialchars( $e['message'], ENT_QUOTES ) . "</div><br />";
-			}
+	if ( isset( $form['errors'] ) ) {
+		foreach ( $form['errors'] as $e ) {
+			$HTML .= "<div class='errorbox'>" .
+				htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
+				$e['message'] . "</div><br />";
 		}
+	}
 	} elseif ( $form['success'] !== null ) {
-		if ( isset( $form['errors'] ) ) {
-			foreach ( $form['errors'] as $e ) {
-				$HTML .= "<div class='errorbox'>" .
-					htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
-					htmlspecialchars( $e['message'], ENT_QUOTES ) . "</div><br />";
-			}
-		} else {
+	if ( isset( $form['errors'] ) ) {
+		foreach ( $form['errors'] as $e ) {
+			$HTML .= "<div class='errorbox'>" .
+				htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
+				$e['message'] . "</div><br />";
+		}
+	} else {
 			$msgKey = $wasAwarded ? 'awarded' : 'unawarded';
 			$statusMsg = wfMessage( $msgKey )->escaped();
 			$HTML .= "<div class='errorbox'>" .
@@ -543,7 +543,7 @@ class TemplateManageAchievements {
 					 )->escaped() . "
 				<br />" . htmlspecialchars( $form['success']['message'] ?? '', ENT_QUOTES ) . "
 				</div>";
-		}
+	}
 	}
 
 		$HTML .= "

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -518,21 +518,21 @@ class TemplateManageAchievements {
 						 "</div><br />";
 			}
 		}
-	if ( isset( $form['errors'] ) ) {
-		foreach ( $form['errors'] as $e ) {
-			$HTML .= "<div class='errorbox'>" .
-				htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
-				$e['message'] . "</div><br />";
+		if ( isset( $form['errors'] ) ) {
+			foreach ( $form['errors'] as $e ) {
+				$HTML .= "<div class='errorbox'>" .
+					htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
+					htmlspecialchars( $e['message'], ENT_QUOTES ) . "</div><br />";
+			}
 		}
-	}
 	} elseif ( $form['success'] !== null ) {
-	if ( isset( $form['errors'] ) ) {
-		foreach ( $form['errors'] as $e ) {
-			$HTML .= "<div class='errorbox'>" .
-				htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
-				$e['message'] . "</div><br />";
-		}
-	} else {
+		if ( isset( $form['errors'] ) ) {
+			foreach ( $form['errors'] as $e ) {
+				$HTML .= "<div class='errorbox'>" .
+					htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
+					htmlspecialchars( $e['message'], ENT_QUOTES ) . "</div><br />";
+			}
+		} else {
 			$msgKey = $wasAwarded ? 'awarded' : 'unawarded';
 			$statusMsg = wfMessage( $msgKey )->escaped();
 			$HTML .= "<div class='errorbox'>" .

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -500,19 +500,21 @@ class TemplateManageAchievements {
 	if ( isset( $form['success'] ) && is_array( $form['success'] ) ) {
 		foreach ( $form['success'] as $s ) {
 			if ( $s['message'] == "success" ) {
-				// Manually build message with escaped username to avoid taint propagation
+				// Build message without user data to avoid taint propagation
 				$msgKey = $wasAwarded ? 'awarded' : 'unawarded';
+				$statusMsg = wfMessage( $msgKey )->escaped();
 				$HTML .= "<div class='successbox'>" .
 						 htmlspecialchars( $s['username'], ENT_QUOTES ) . " " .
-						 wfMessage( 'achievement_awarded_to_suffix', wfMessage( $msgKey )->text() )->parse() .
+						 wfMessage( 'achievement_awarded_to_suffix', $statusMsg )->escaped() .
 						 "</div><br />";
 			}
 			if ( $s['message'] == "nochange" ) {
-				// Manually build message with escaped username to avoid taint propagation
+				// Build message without user data to avoid taint propagation
 				$msgKey = $wasAwarded ? 'awarded' : 'unawarded';
+				$statusMsg = wfMessage( $msgKey )->escaped();
 				$HTML .= "<div class='successbox'>" .
 						 htmlspecialchars( $s['username'], ENT_QUOTES ) . " " .
-						 wfMessage( 'achievement_nochange_to_suffix', wfMessage( $msgKey )->text() )->parse() .
+						 wfMessage( 'achievement_nochange_to_suffix', $statusMsg )->escaped() .
 						 "</div><br />";
 			}
 		}
@@ -532,13 +534,14 @@ class TemplateManageAchievements {
 			}
 		} else {
 			$msgKey = $wasAwarded ? 'awarded' : 'unawarded';
+			$statusMsg = wfMessage( $msgKey )->escaped();
 			$HTML .= "<div class='errorbox'>" .
 					 wfMessage(
 						 'achievement_award_failed',
-						 mb_strtolower( wfMessage( $msgKey )->text(), 'UTF-8' ),
-						 mb_strtolower( wfMessage( $msgKey )->text(), 'UTF-8' )
-					 )->parse() . "
-				<br />" . htmlspecialchars( $form['success']['message'], ENT_QUOTES ) . "
+						 mb_strtolower( $statusMsg, 'UTF-8' ),
+						 mb_strtolower( $statusMsg, 'UTF-8' )
+					 )->escaped() . "
+				<br />" . htmlspecialchars( $form['success']['message'] ?? '', ENT_QUOTES ) . "
 				</div>";
 		}
 	}

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -535,15 +535,15 @@ class TemplateManageAchievements {
 						 wfMessage(
 							 'achievement_award_failed',
 							 mb_strtolower(
-								 $wasAwarded ? wfMessage( 'awarded' ) : wfMessage( 'unawarded' ),
+								 $wasAwarded ? wfMessage( 'awarded' )->text() : wfMessage( 'unawarded' )->text(),
 								 'UTF-8'
 							 ),
 							 mb_strtolower(
-								 $wasAwarded ? wfMessage( 'awarded' ) : wfMessage( 'unawarded' ),
+								 $wasAwarded ? wfMessage( 'awarded' )->text() : wfMessage( 'unawarded' )->text(),
 								 'UTF-8'
 							 )
-						 )->escaped() . "
-					<br />" . $form['success']['message'] . "
+						 )->text() . "
+					<br />" . htmlspecialchars( $form['success']['message'], ENT_QUOTES ) . "
 					</div>";
 		}
 	}

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -543,7 +543,7 @@ class TemplateManageAchievements {
 					 )->escaped() . "
 				<br />" . htmlspecialchars( $form['success']['message'] ?? '', ENT_QUOTES ) . "
 				</div>";
-	}
+		}
 	}
 
 		$HTML .= "

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -14,12 +14,10 @@ namespace Cheevos\Templates;
 
 use Cheevos\CheevosAchievement;
 use Cheevos\CheevosHelper;
-use Exception;
-use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
-use MediaWiki\SpecialPage\SpecialPage;
+use RequestContext;
+use SpecialPage;
 
-// phpcs:disable Generic.Files.LineLength.TooLong
 class TemplateManageAchievements {
 	/**
 	 * Achievement List
@@ -27,11 +25,10 @@ class TemplateManageAchievements {
 	 * @param array $achievements Array of Achievement Object
 	 * @param array $categories Array of Category Information
 	 * @param array $revertHints Array of achievements that can be reverted.
-	 *        All child achievements can be reverted, but this hides the button if the child achievement
-	 *        is effectively the same as the parent.
+	 * 		All child achievements can be reverted, but this hides the button if the child achievement
+	 * 		is effectively the same as the parent.
 	 *
 	 * @return string Built HTML
-	 * @throws Exception
 	 */
 	public function achievementsList( array $achievements, array $categories, array $revertHints ): string {
 		$context = RequestContext::getMain();
@@ -66,15 +63,15 @@ class TemplateManageAchievements {
 			<div class='button_break'></div>
 			<div class='buttons_right'>
 				" . ( $user->isAllowed( 'achievement_admin' ) ?
-					"<a href='$achievementsURL/invalidatecache' class='mw-ui-button mw-ui-destructive'>" .
+					"<a href='{$achievementsURL}/invalidatecache' class='mw-ui-button mw-ui-destructive'>" .
 					wfMessage( 'invalidatecache_achievement' ) .
 					"</a>" : null ) . "
 				" . ( $user->isAllowed( 'achievement_admin' ) ?
-					"<a href='$achievementsURL/award' class='mw-ui-button'>" .
+					"<a href='{$achievementsURL}/award' class='mw-ui-button'>" .
 					wfMessage( 'award_achievement' ) .
 					"</a>" : null ) . "
 				" . ( $user->isAllowed( 'achievement_admin' ) ?
-					"<a href='$achievementsURL/add' class='mw-ui-button mw-ui-progressive'>" .
+					"<a href='{$achievementsURL}/add' class='mw-ui-button mw-ui-progressive'>" .
 					wfMessage( 'add_achievement' ) .
 					"</a>" : null ) . "
 			</div>
@@ -86,7 +83,7 @@ class TemplateManageAchievements {
 			$HTML .= "
 			<ul id='achievement_categories'>";
 			$firstCategory = true;
-			foreach ( $categories as $category ) {
+			foreach ( $categories as $categoryIndex => $category ) {
 				$categoryId = $category->getId();
 				$categoryHTML[$categoryId] = '';
 				foreach ( $achievements as $achievementId => $achievement ) {
@@ -120,7 +117,7 @@ class TemplateManageAchievements {
 				<h4 class='achievement_category_title'>" .
 							 htmlentities( $category->getName(), ENT_QUOTES ) .
 				"</h4>
-				$categoryHTML[$categoryId]
+				{$categoryHTML[$categoryId]}
 			</div>";
 				}
 			}
@@ -144,9 +141,7 @@ class TemplateManageAchievements {
 	 * @param array $categories Achievement Categories
 	 * @param array $allAchievements All Achievements
 	 * @param array $errors Key name => Error of errors
-	 *
 	 * @return string Built HTML
-	 * @throws Exception
 	 */
 	public function achievementsForm(
 		CheevosAchievement $achievement,
@@ -177,7 +172,7 @@ class TemplateManageAchievements {
 				id='achievement_form'
 				class=\"pure-form pure-form-stacked\"
 				method='post'
-				action='$achievementsURL/admin?do=save'>
+				action='{$achievementsURL}/admin?do=save'>
 				<fieldset>
 					" . ( isset( $errors['name'] ) ? '<span class="error">' . $errors['name'] . '</span>' : '' ) . "
 					<label for='name' class='label_above'>" .
@@ -223,10 +218,10 @@ class TemplateManageAchievements {
 		if ( count( $categories ) ) {
 			$HTML .= "<select id='achievement_category_select'>
 									<option value='0'></option>\n";
-			foreach ( $categories as $category ) {
+			foreach ( $categories as $gid => $category ) {
 				$acid = $category->getId();
 				$HTML .= "<option
-				value='$acid'" . ( $achievement->getCategoryId() == $acid ? " selected='selected'" : null ) . ">"
+				value='{$acid}'" . ( $achievement->getCategoryId() == $acid ? " selected='selected'" : null ) . ">"
 						 . htmlentities( $category->getTitle(), ENT_QUOTES ) .
 						 "</option>\n";
 			}
@@ -236,7 +231,7 @@ class TemplateManageAchievements {
 
 		$HTML .= ( isset( $errors['image'] ) ? '<span class="error">' . $errors['image'] . '</span>' : '' ) . "
 			<div id='image_upload'>
-				<img id='image_loading' alt='Loading image' src='" . MediaWikiServices::getInstance()->getUrlUtils()->expand(
+				<img id='image_loading' src='" . MediaWikiServices::getInstance()->getUrlUtils()->expand(
 					$wgExtensionAssetsPath . "/Cheevos/images/loading.gif"
 			) . "'/>
 				<p class='image_hint'>" . wfMessage( 'image_hint' )->escaped() . "</p>
@@ -317,8 +312,8 @@ class TemplateManageAchievements {
 			<span>" . wfMessage( 'criteria_stats_help' ) . "</span></div></label>
 			<div class='criteria_container'>";
 			foreach ( $wgCheevosStats as $stat ) {
-				$HTML .= "<label><input type='checkbox' name='criteria_stats[]' value='$stat'" .
-					( in_array( $stat, $stats ) ? " checked='checked'" : null ) . "/>$stat</label>";
+				$HTML .= "<label><input type='checkbox' name='criteria_stats[]' value='{$stat}'" .
+						 ( in_array( $stat, $stats ) ? " checked='checked'" : null ) . "/>{$stat}</label>";
 			}
 			$HTML .= "</div>
 
@@ -332,7 +327,7 @@ class TemplateManageAchievements {
 					 "</span></div></label>
 				<select name='criteria_streak'>";
 			foreach ( $streakEnum as $streak ) {
-				$HTML .= "<option value='$streak' " .
+				$HTML .= "<option value='{$streak}' " .
 						 ( ( isset( $criteria['streak'] ) && $criteria['streak'] == $streak ) ? 'selected' : '' ) .
 						 ">" . ucfirst( $streak ) . "</option>";
 			}
@@ -429,10 +424,10 @@ class TemplateManageAchievements {
 					<option value='0'>(0) None</option>";
 			foreach ( $categories as $category ) {
 				$acid = $category->getId();
-				$HTML .= "<option value='$acid'" . (
+				$HTML .= "<option value='{$acid}'" . (
 					( isset( $criteria['category_id'] ) &&
 					  $criteria['category_id'] == $acid ) ? " selected='selected'" : null
-					) . ">($acid) " . htmlentities( $category->getTitle(), ENT_QUOTES ) . "</option>\n";
+					) . ">({$acid}) " . htmlentities( $category->getTitle(), ENT_QUOTES ) . "</option>\n";
 			}
 			$HTML .= "</select>
 
@@ -444,7 +439,7 @@ class TemplateManageAchievements {
 			<div class='criteria_container'>";
 			if ( count( $allAchievements ) ) {
 				$seenIds = [];
-				foreach ( $allAchievements as $info ) {
+				foreach ( $allAchievements as $aid => $info ) {
 					$id = ( $info->getParent_Id() ? $info->getParent_Id() : $info->getId() );
 					if ( $info->getId() == $achievement->getId() || isset( $seenIds[$id] ) ) {
 						continue;
@@ -452,7 +447,7 @@ class TemplateManageAchievements {
 					$HTML .= "<label><input
 						type='checkbox'
 						name='criteria_achievement_ids[]'
-						value='$id'" . (
+						value='{$id}'" . (
 							in_array( $info->getId(), $criteria['achievement_ids'] ) ||
 							in_array(
 								$info->getParent_Id(), $criteria['achievement_ids'] ) ? " checked='checked'" : null
@@ -496,97 +491,86 @@ class TemplateManageAchievements {
 		$awardUrl = SpecialPage::getSafeTitleFor( 'ManageAchievements', 'award' )->getFullURL();
 
 		$HTML = '';
-	$wasAwarded = $request->getVal( 'do' ) === 'award';
-	if ( isset( $form['success'] ) && is_array( $form['success'] ) ) {
-		foreach ( $form['success'] as $s ) {
-			if ( $s['message'] == "success" ) {
-				// Build message without user data to avoid taint propagation
-				$msgKey = $wasAwarded ? 'awarded' : 'unawarded';
-				$statusMsg = wfMessage( $msgKey )->escaped();
-				$HTML .= "<div class='successbox'>" .
-						 htmlspecialchars( $s['username'], ENT_QUOTES ) . " " .
-						 wfMessage( 'achievement_awarded_to_suffix', $statusMsg )->escaped() .
-						 "</div><br />";
+		$wasAwarded = $request->getVal( 'do' ) === 'award';
+		if ( isset( $form['success'] ) && is_array( $form['success'] ) ) {
+			foreach ( $form['success'] as $s ) {
+				if ( $s['message'] == "success" ) {
+					$HTML .= "<div class='successbox'>" .
+							 wfMessage(
+								 'achievement_awarded_to',
+								 $s['username'],
+								 $wasAwarded ? wfMessage( 'awarded' ) : wfMessage( 'unawarded' )
+							 )->escaped() . "</div><br />";
+				}
+				if ( $s['message'] == "nochange" ) {
+					$HTML .= "<div class='successbox'>" .
+							 wfMessage(
+								 'achievement_nochange_to',
+								 $s['username'],
+								 $wasAwarded ? wfMessage( 'awarded' ) : wfMessage( 'unawarded' )
+							 )->escaped() . "</div><br />";
+				}
 			}
-			if ( $s['message'] == "nochange" ) {
-				// Build message without user data to avoid taint propagation
-				$msgKey = $wasAwarded ? 'awarded' : 'unawarded';
-				$statusMsg = wfMessage( $msgKey )->escaped();
-				$HTML .= "<div class='successbox'>" .
-						 htmlspecialchars( $s['username'], ENT_QUOTES ) . " " .
-						 wfMessage( 'achievement_nochange_to_suffix', $statusMsg )->escaped() .
-						 "</div><br />";
+			if ( isset( $form['errors'] ) ) {
+				foreach ( $form['errors'] as $e ) {
+					$HTML .= "<div class='errorbox'>" . $e['username'] . ": " . $e['message'] . "</div><br />";
+				}
 			}
-		}
-		if ( isset( $form['errors'] ) ) {
-			foreach ( $form['errors'] as $e ) {
-				// Look up message from key to avoid taint propagation
-				$messageText = isset( $e['message_key'] ) ?
-					wfMessage( $e['message_key'] )->escaped() :
-					htmlspecialchars( $e['message'] ?? '', ENT_QUOTES );
+		} elseif ( $form['success'] !== null ) {
+			if ( isset( $form['errors'] ) ) {
+				foreach ( $form['errors'] as $e ) {
+					$HTML .= "<div class='errorbox'>" . $e['username'] . ": " . $e['message'] . "</div><br />";
+				}
+			} else {
 				$HTML .= "<div class='errorbox'>" .
-					htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
-					$messageText . "</div><br />";
+						 wfMessage(
+							 'achievement_award_failed',
+							 mb_strtolower(
+								 $wasAwarded ? wfMessage( 'awarded' ) : wfMessage( 'unawarded' ),
+								 'UTF-8'
+							 ),
+							 mb_strtolower(
+								 $wasAwarded ? wfMessage( 'awarded' ) : wfMessage( 'unawarded' ),
+								 'UTF-8'
+							 )
+						 )->escaped() . "
+					<br />" . $form['success']['message'] . "
+					</div>";
 			}
 		}
-	} elseif ( $form['success'] !== null ) {
-		if ( isset( $form['errors'] ) ) {
-			foreach ( $form['errors'] as $e ) {
-				// Look up message from key to avoid taint propagation
-				$messageText = isset( $e['message_key'] ) ?
-					wfMessage( $e['message_key'] )->escaped() :
-					htmlspecialchars( $e['message'] ?? '', ENT_QUOTES );
-				$HTML .= "<div class='errorbox'>" .
-					htmlspecialchars( $e['username'], ENT_QUOTES ) . ": " .
-					$messageText . "</div><br />";
-			}
-		} else {
-			$msgKey = $wasAwarded ? 'awarded' : 'unawarded';
-			$statusMsg = wfMessage( $msgKey )->escaped();
-			$HTML .= "<div class='errorbox'>" .
-					 wfMessage(
-						 'achievement_award_failed',
-						 mb_strtolower( $statusMsg, 'UTF-8' ),
-						 mb_strtolower( $statusMsg, 'UTF-8' )
-					 )->escaped() . "
-				<br />" . htmlspecialchars( $form['success']['message'] ?? '', ENT_QUOTES ) . "
-				</div>";
-		}
-	}
 
 		$HTML .= "
 		<form action='$awardUrl' id='mw-awardachievement-form' method='post' name='mw-awardachievement-form'>
 			<fieldset>
-		<legend>" . wfMessage( 'award_hint' )->escaped() . "</legend>";
-	if ( isset( $form['errors']['username'] ) ) {
-		foreach ( $form['errors']['username'] as $err ) {
-			$HTML .= '<span class="error">' . htmlspecialchars( $err, ENT_QUOTES ) . '</span><br/>';
+				<legend>" . wfMessage( 'award_hint' )->escaped() . "</legend>";
+		if ( isset( $form['errors']['username'] ) ) {
+			foreach ( $form['errors']['username'] as $err ) {
+				$HTML .= '<span class="error">' . $err . '</span><br/>';
+			}
 		}
-	}
-		$HTML .= "<label for='offset'>" . wfMessage( 'local_username' )->escaped() . "</label>
-			<textarea
-				id='username_list'
-				name='username'
-				placeholder='Single username, or comma delimited list of usernames.'>" .
-					( isset( $form['save']['username'] ) ?
-						htmlspecialchars( $form['save']['username'], ENT_QUOTES ) : '' ) . "</textarea>";
-	if ( is_array( $achievements ) && count( $achievements ) ) {
+				$HTML .= "<label for='offset'>" . wfMessage( 'local_username' )->escaped() . "</label>
+				<textarea
+					id='username_list'
+					name='username'
+					placeholder='Single username, or comma delimited list of usernames.'>" .
+						 ( isset( $form['save']['username'] ) ? $form['save']['username'] : '' ) . "</textarea>";
+		if ( is_array( $achievements ) && count( $achievements ) ) {
 			$HTML .= "
 				" . (
 					isset( $form['errors']['achievement_id'] ) ?
 						'<span class="error">' . $form['errors']['achievement_id'] . '</span><br/>' : '' ) . "
 				<select id='achievement_id' name='achievement_id'>\n";
-			foreach ( $achievements as $achievement ) {
+			foreach ( $achievements as $key => $achievement ) {
 				$achievementId = $achievement->getId();
 				$HTML .= "
-					<option value='$achievementId'" .
+					<option value='{$achievementId}'" .
 						 ( isset( $form['save']['achievement_id'] ) &&
 						   $form['save']['achievement_id'] == $achievementId ? " selected='selected'" : null ) .
 						 ">" . htmlentities( $achievement->getName(), ENT_QUOTES ) . "</option>\n";
 			}
 			$HTML .= "
 				</select><br/>";
-	}
+		}
 		$HTML .= "
 				<input name='type' type='hidden' value='local'/>
 				<button name='do' type='submit' value='award'>" .
@@ -599,4 +583,3 @@ class TemplateManageAchievements {
 		return $HTML;
 	}
 }
-// phpcs:enable

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -15,7 +15,7 @@ namespace Cheevos\Templates;
 use Cheevos\CheevosAchievement;
 use Cheevos\CheevosHelper;
 use MediaWiki\MediaWikiServices;
-use RequestContext;
+use MediaWiki\Context\RequestContext;
 use SpecialPage;
 
 class TemplateManageAchievements {

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -14,8 +14,8 @@ namespace Cheevos\Templates;
 
 use Cheevos\CheevosAchievement;
 use Cheevos\CheevosHelper;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Context\RequestContext;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\SpecialPage\SpecialPage;
 
 class TemplateManageAchievements {

--- a/src/Templates/TemplatePointsComp.php
+++ b/src/Templates/TemplatePointsComp.php
@@ -83,17 +83,17 @@ class TemplatePointsComp {
 
 		if ( count( $reports ) ) {
 			$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
-			foreach ( $reports as $report ) {
-				$html .= "
-				<tr>
-					<td>" . $linkRenderer->makeKnownLink(
-						SpecialPage::getTitleFor( 'PointsComp', $report->getReportId() ),
-						wfMessage(
-							'comp_report_link',
-							$report->getReportId(),
-							gmdate( 'Y-m-d', $report->getRunTime() )
-						)->escaped()
-					) . "</td>
+		foreach ( $reports as $report ) {
+			$html .= "
+			<tr>
+				<td>" . $linkRenderer->makeKnownLink(
+					SpecialPage::getTitleFor( 'PointsComp', (string)$report->getReportId() ),
+					wfMessage(
+						'comp_report_link',
+						$report->getReportId(),
+						gmdate( 'Y-m-d', $report->getRunTime() )
+					)->text()
+				) . "</td>
 					<td>{$report->getMinPointThreshold()}</td>
 					<td>{$report->getMaxPointThreshold()}</td>
 					<td>" . gmdate( 'Y-m-d', $report->getStartTime() ) . "</td>
@@ -107,7 +107,7 @@ class TemplatePointsComp {
 					<td>{$report->getTotalEmailed()}</td>
 					<td>" . ( $report->isFinished() ? '✓' : '&nbsp;' ) . "</td>
 				</tr>";
-			}
+		}
 		}
 		$html .= "
 			</tbody>

--- a/src/Templates/TemplatePointsComp.php
+++ b/src/Templates/TemplatePointsComp.php
@@ -83,17 +83,17 @@ class TemplatePointsComp {
 
 		if ( count( $reports ) ) {
 			$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
-		foreach ( $reports as $report ) {
-			$html .= "
-			<tr>
-				<td>" . $linkRenderer->makeKnownLink(
-					SpecialPage::getTitleFor( 'PointsComp', (string)$report->getReportId() ),
-					wfMessage(
-						'comp_report_link',
-						$report->getReportId(),
-						gmdate( 'Y-m-d', $report->getRunTime() )
-					)->text()
-				) . "</td>
+			foreach ( $reports as $report ) {
+				$html .= "
+				<tr>
+					<td>" . $linkRenderer->makeKnownLink(
+						SpecialPage::getTitleFor( 'PointsComp', (string)$report->getReportId() ),
+						wfMessage(
+							'comp_report_link',
+							$report->getReportId(),
+							gmdate( 'Y-m-d', $report->getRunTime() )
+						)->text()
+					) . "</td>
 					<td>{$report->getMinPointThreshold()}</td>
 					<td>{$report->getMaxPointThreshold()}</td>
 					<td>" . gmdate( 'Y-m-d', $report->getStartTime() ) . "</td>
@@ -107,7 +107,7 @@ class TemplatePointsComp {
 					<td>{$report->getTotalEmailed()}</td>
 					<td>" . ( $report->isFinished() ? '✓' : '&nbsp;' ) . "</td>
 				</tr>";
-		}
+			}
 		}
 		$html .= "
 			</tbody>

--- a/src/Templates/TemplateWikiPoints.php
+++ b/src/Templates/TemplateWikiPoints.php
@@ -93,34 +93,34 @@ class TemplateWikiPoints {
 	 * @return string Anchor links.
 	 */
 	public static function getWikiPointsLinks(): string {
-		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
-		$cheevosHelper = MediaWikiServices::getInstance()->getService( CheevosHelper::class );
-		$links = [
-			$linkRenderer->makeKnownLink(
-				SpecialPage::getTitleFor( 'WikiPoints' ),
-				wfMessage( 'top_wiki_editors' )->escaped()
-			),
-			$linkRenderer->makeKnownLink(
-				SpecialPage::getTitleFor( 'WikiPoints', 'monthly' ),
-				wfMessage( 'top_wiki_editors_monthly' )->escaped()
-			),
-			$linkRenderer->makeKnownLink(
-				SpecialPage::getTitleFor( 'WikiPoints', 'global' ),
-				wfMessage( 'top_wiki_editors_global' )->escaped()
-			)
-		];
-		if ( $cheevosHelper->isCheevosCentralWiki() ) {
-			$links[] = $linkRenderer->makeKnownLink(
-				SpecialPage::getTitleFor( 'WikiPoints', 'sites' ),
-				wfMessage( 'top_wiki_editors_sites' )->escaped()
-			);
-			$links[] = $linkRenderer->makeKnownLink(
-				SpecialPage::getTitleFor( 'WikiPoints', 'sites/monthly' ),
-				wfMessage( 'top_wiki_editors_sites_monthly' )->escaped()
-			);
-		}
+	$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
+	$cheevosHelper = MediaWikiServices::getInstance()->getService( CheevosHelper::class );
+	$links = [
+		$linkRenderer->makeKnownLink(
+			SpecialPage::getTitleFor( 'WikiPoints' ),
+			wfMessage( 'top_wiki_editors' )->text()
+		),
+		$linkRenderer->makeKnownLink(
+			SpecialPage::getTitleFor( 'WikiPoints', 'monthly' ),
+			wfMessage( 'top_wiki_editors_monthly' )->text()
+		),
+		$linkRenderer->makeKnownLink(
+			SpecialPage::getTitleFor( 'WikiPoints', 'global' ),
+			wfMessage( 'top_wiki_editors_global' )->text()
+		)
+	];
+	if ( $cheevosHelper->isCheevosCentralWiki() ) {
+		$links[] = $linkRenderer->makeKnownLink(
+			SpecialPage::getTitleFor( 'WikiPoints', 'sites' ),
+			wfMessage( 'top_wiki_editors_sites' )->text()
+		);
+		$links[] = $linkRenderer->makeKnownLink(
+			SpecialPage::getTitleFor( 'WikiPoints', 'sites/monthly' ),
+			wfMessage( 'top_wiki_editors_sites_monthly' )->text()
+		);
+	}
 
-		return implode( ' | ', $links ) . "<hr>";
+	return implode( ' | ', $links ) . "<hr>";
 	}
 
 	/**

--- a/src/Templates/TemplateWikiPoints.php
+++ b/src/Templates/TemplateWikiPoints.php
@@ -93,34 +93,34 @@ class TemplateWikiPoints {
 	 * @return string Anchor links.
 	 */
 	public static function getWikiPointsLinks(): string {
-	$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
-	$cheevosHelper = MediaWikiServices::getInstance()->getService( CheevosHelper::class );
-	$links = [
-		$linkRenderer->makeKnownLink(
-			SpecialPage::getTitleFor( 'WikiPoints' ),
-			wfMessage( 'top_wiki_editors' )->text()
-		),
-		$linkRenderer->makeKnownLink(
-			SpecialPage::getTitleFor( 'WikiPoints', 'monthly' ),
-			wfMessage( 'top_wiki_editors_monthly' )->text()
-		),
-		$linkRenderer->makeKnownLink(
-			SpecialPage::getTitleFor( 'WikiPoints', 'global' ),
-			wfMessage( 'top_wiki_editors_global' )->text()
-		)
-	];
-	if ( $cheevosHelper->isCheevosCentralWiki() ) {
-		$links[] = $linkRenderer->makeKnownLink(
-			SpecialPage::getTitleFor( 'WikiPoints', 'sites' ),
-			wfMessage( 'top_wiki_editors_sites' )->text()
-		);
-		$links[] = $linkRenderer->makeKnownLink(
-			SpecialPage::getTitleFor( 'WikiPoints', 'sites/monthly' ),
-			wfMessage( 'top_wiki_editors_sites_monthly' )->text()
-		);
-	}
+		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
+		$cheevosHelper = MediaWikiServices::getInstance()->getService( CheevosHelper::class );
+		$links = [
+			$linkRenderer->makeKnownLink(
+				SpecialPage::getTitleFor( 'WikiPoints' ),
+				wfMessage( 'top_wiki_editors' )->text()
+			),
+			$linkRenderer->makeKnownLink(
+				SpecialPage::getTitleFor( 'WikiPoints', 'monthly' ),
+				wfMessage( 'top_wiki_editors_monthly' )->text()
+			),
+			$linkRenderer->makeKnownLink(
+				SpecialPage::getTitleFor( 'WikiPoints', 'global' ),
+				wfMessage( 'top_wiki_editors_global' )->text()
+			)
+		];
+		if ( $cheevosHelper->isCheevosCentralWiki() ) {
+			$links[] = $linkRenderer->makeKnownLink(
+				SpecialPage::getTitleFor( 'WikiPoints', 'sites' ),
+				wfMessage( 'top_wiki_editors_sites' )->text()
+			);
+			$links[] = $linkRenderer->makeKnownLink(
+				SpecialPage::getTitleFor( 'WikiPoints', 'sites/monthly' ),
+				wfMessage( 'top_wiki_editors_sites_monthly' )->text()
+			);
+		}
 
-	return implode( ' | ', $links ) . "<hr>";
+		return implode( ' | ', $links ) . "<hr>";
 	}
 
 	/**


### PR DESCRIPTION
PR: https://fandom.atlassian.net/browse/CTOOLS-2355

This pull request focuses on improving security and maintainability in the achievement management system, primarily by enhancing HTML escaping to prevent XSS vulnerabilities, refactoring service dependencies, and cleaning up code for clarity and consistency.

**Security and HTML Escaping Improvements:**
- Consistently applied `htmlspecialchars()` to user-supplied values in `TemplateManageAchievements.php` to prevent XSS, especially in error and success messages, usernames, and achievement names. [[1]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L506-R526) [[2]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L542-R541) [[3]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L553-R570)
- Updated calls to `wfMessage(...)->escaped()` or `->text()` as appropriate, ensuring proper output escaping in both `TemplateManageAchievements.php` and `SpecialManageAchievements.php`. [[1]](diffhunk://#diff-6b58d6dcefc3514b1250b525d3a896474a47d5681635a570fdc5910845db09efL479-R482) [[2]](diffhunk://#diff-6b58d6dcefc3514b1250b525d3a896474a47d5681635a570fdc5910845db09efL488-R491) [[3]](diffhunk://#diff-6b58d6dcefc3514b1250b525d3a896474a47d5681635a570fdc5910845db09efL503-R506) [[4]](diffhunk://#diff-12399b83ccacacb966d5562ee13cc31d46063fe691217df529f3f1e4c6a65fb8L394-R394) [[5]](diffhunk://#diff-6b1b7ed0f640a041ed6d42e12bb0c78f6f3448738e7b4c3d4caa758354cbc232L90-R95)

**HTML and Template Code Quality:**
- Standardized variable interpolation in HTML attributes to use curly braces (e.g., `{$var}`) for clarity and consistency. [[1]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L69-R74) [[2]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L89-R86) [[3]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L123-R120) [[4]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L180-R175) [[5]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L226-R224) [[6]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L239-R234) [[7]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L320-R316) [[8]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L335-R330) [[9]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L432-R430) [[10]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L447-R450) [[11]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L553-R570)
- Removed unused imports and exception annotations in `TemplateManageAchievements.php` for cleaner code. [[1]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L17-L22) [[2]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L34) [[3]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L147-L149)
- Added a Phan suppression comment to clarify escaping logic in `SpecialManageAchievements.php`.

**Other Minor Improvements:**
- Casted report IDs to string for compatibility in `TemplatePointsComp.php` and switched to using unescaped text for message rendering.

These changes collectively enhance the security, maintainability, and readability of the achievement management codebase.