### PR TITLE
CTOOLS-2371 (fix): Enhance HTML escaping in TemplateManageAchievements

### DIFF
--- a/js/cheevos.js
+++ b/js/cheevos.js
@@ -61,11 +61,11 @@ $(function() {
 	/* Preview Updating          */
 	/*****************************/
 	$("input[name='name']").keyup(function() {
-		$('.p-achievement-name').html($(this).val());
+	$('.p-achievement-name').text($(this).val());
 	}).keyup();
 
 	$("input[name='description']").keyup(function() {
-		$('.p-achievement-description').html($(this).val());
+	$('.p-achievement-description').text($(this).val());
 	}).keyup();
 
 	$("input[name='image_url']").keyup(function() {
@@ -75,9 +75,9 @@ $(function() {
 	$("input[name='points']").keyup(function() {
 		var points = $(this).val();
 		if (points > 0) {
-			$('.p-achievement-points').html($(this).val());
+			$('.p-achievement-points').text($(this).val());
 		} else {
-			$('.p-achievement-points').html('');
+			$('.p-achievement-points').text('');
 		}
 	}).keyup();
 
@@ -85,7 +85,7 @@ $(function() {
 		var increment = $(this).val();
 		if (increment > 0) {
 			var progressDiv = $('<div>').addClass('p-achievement-progress');
-			var spanNumbers = $('<span>').append('0/' + increment);
+			var spanNumbers = $('<span>').text('0/' + increment);
 			var bar = $('<div>').addClass('progress-background').append($('<div>').addClass('progress-bar').attr('style', 'width: 0%;'));
 			if ($('.p-achievement-progress').length > 0) {
 				$('.p-achievement-progress').replaceWith(progressDiv.append(spanNumbers).append(bar));
@@ -340,7 +340,7 @@ $(function() {
 							if ($.inArray(result.achievements[achievementId].unique_hash, window.megaAchievementRequires) !== -1) {
 								$(input).attr('checked', true);
 							}
-							var achievementRow = $('<label>').append(input).append(result.achievements[achievementId].name);
+							var achievementRow = $('<label>').append(input).append(document.createTextNode(result.achievements[achievementId].name));
 							$('#achievements_container').append(achievementRow);
 						}
 					}

--- a/js/cheevos.js
+++ b/js/cheevos.js
@@ -61,11 +61,11 @@ $(function() {
 	/* Preview Updating          */
 	/*****************************/
 	$("input[name='name']").keyup(function() {
-	$('.p-achievement-name').text($(this).val());
+		$('.p-achievement-name').text($(this).val());
 	}).keyup();
 
 	$("input[name='description']").keyup(function() {
-	$('.p-achievement-description').text($(this).val());
+		$('.p-achievement-description').text($(this).val());
 	}).keyup();
 
 	$("input[name='image_url']").keyup(function() {

--- a/src/Specials/SpecialManageAchievements.php
+++ b/src/Specials/SpecialManageAchievements.php
@@ -234,14 +234,14 @@ class SpecialManageAchievements extends SpecialPage {
 
 		$name = $request->getText( 'name' );
 		if ( !$name || strlen( $name ) > 50 ) {
-			$errors['name'] = $this->msg( 'error_invalid_achievement_name' )->escaped();
+			$errors['name'] = $this->msg( 'error_invalid_achievement_name' )->text();
 		} else {
 			$achievement->setName( $name );
 		}
 
 		$description = $request->getText( 'description' );
 		if ( !$description || strlen( $description ) > 150 ) {
-			$errors['description'] = $this->msg( 'error_invalid_achievement_description' )->escaped();
+			$errors['description'] = $this->msg( 'error_invalid_achievement_description' )->text();
 		} else {
 			$achievement->setDescription( $description );
 		}
@@ -287,7 +287,7 @@ class SpecialManageAchievements extends SpecialPage {
 		}
 
 		if ( $category === false ) {
-			$errors['category'] = $this->msg( 'error_invalid_achievement_category' )->escaped();
+			$errors['category'] = $this->msg( 'error_invalid_achievement_category' )->text();
 		}
 
 		$achievement->setSecret( $request->getBool( 'secret' ) );
@@ -455,9 +455,6 @@ class SpecialManageAchievements extends SpecialPage {
 		);
 
 		$output->setPageTitle( $this->msg( 'awardachievement' )->escaped() );
-		// Phan can't track escaping through complex array structures passed to templates.
-		// The template properly escapes all user input with htmlspecialchars().
-		// @phan-suppress-next-line SecurityCheck-XSS
 		$output->addHTML( $this->template->awardForm( $return, $allAchievements ) );
 	}
 

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -174,7 +174,7 @@ class TemplateManageAchievements {
 				method='post'
 				action='{$achievementsURL}/admin?do=save'>
 				<fieldset>
-					" . ( isset( $errors['name'] ) ? '<span class="error">' . $errors['name'] . '</span>' : '' ) . "
+					" . ( isset( $errors['name'] ) ? '<span class="error">' . htmlspecialchars( $errors['name'], ENT_QUOTES ) . '</span>' : '' ) . "
 					<label for='name' class='label_above'>" .
 						wfMessage( 'achievement_name' )->escaped() .
 					"</label>
@@ -187,7 +187,7 @@ class TemplateManageAchievements {
 						value='" . htmlentities( $achievement->getName(), ENT_QUOTES ) . "' />
 
 					" . ( isset( $errors['description'] ) ?
-						'<span class="error">' . $errors['description'] . '</span>' :
+						'<span class="error">' . htmlspecialchars( $errors['description'], ENT_QUOTES ) . '</span>' :
 						'' ) . "
 					<label for='description' class='label_above'>" .
 						wfMessage( 'achievement_description' )->escaped() .
@@ -201,7 +201,7 @@ class TemplateManageAchievements {
 						value='" . htmlentities( $achievement->getDescription(), ENT_QUOTES ) . "' />
 
 					" . ( isset( $errors['category'] ) ?
-				'<span class="error">' . $errors['category'] . '</span>' :
+				'<span class="error">' . htmlspecialchars( $errors['category'], ENT_QUOTES ) . '</span>' :
 				'' ) . "
 					<label for='category' class='label_above'>" .
 						 wfMessage( 'achievement_category' )->escaped() .
@@ -229,7 +229,7 @@ class TemplateManageAchievements {
 
 		}
 
-		$HTML .= ( isset( $errors['image'] ) ? '<span class="error">' . $errors['image'] . '</span>' : '' ) . "
+		$HTML .= ( isset( $errors['image'] ) ? '<span class="error">' . htmlspecialchars( $errors['image'], ENT_QUOTES ) . '</span>' : '' ) . "
 			<div id='image_upload'>
 				<img id='image_loading' src='" . MediaWikiServices::getInstance()->getUrlUtils()->expand(
 					$wgExtensionAssetsPath . "/Cheevos/images/loading.gif"
@@ -245,7 +245,7 @@ class TemplateManageAchievements {
 			type='text'
 			value='" . htmlentities( $achievement->getImage(), ENT_QUOTES ) . "' />
 
-			" . ( isset( $errors['points'] ) ? '<span class="error">' . $errors['points'] . '</span>' : '' ) . "
+			" . ( isset( $errors['points'] ) ? '<span class="error">' . htmlspecialchars( $errors['points'], ENT_QUOTES ) . '</span>' : '' ) . "
 			<label for='points' class='label_above'>" .
 				 wfMessage( 'achievement_points' )->escaped() .
 				 "<div class='helper_mark'><span>" . wfMessage( 'points_help' ) . "</span></div></label>
@@ -356,7 +356,7 @@ class TemplateManageAchievements {
 					 ) . ">True</option>
 				</select>
 
-				" . ( isset( $errors['date_range_start'] ) ? '<span class="error">' . $errors['date_range_start'] .
+				" . ( isset( $errors['date_range_start'] ) ? '<span class="error">' . htmlspecialchars( $errors['date_range_start'], ENT_QUOTES ) .
 															 '</span>' : '' ) . "
 				<label for='date_range_start' class='label_above'>" .
 					 wfMessage( 'criteria_not_before' )->escaped() . "</label>
@@ -376,7 +376,7 @@ class TemplateManageAchievements {
 
 				" . (
 					isset( $errors['date_range_end'] ) ?
-						'<span class="error">' . $errors['date_range_end'] . '</span>' :
+						'<span class="error">' . htmlspecialchars( $errors['date_range_end'], ENT_QUOTES ) . '</span>' :
 						'' ) . "
 				<label for='date_range_end' class='label_above'>" .
 					 wfMessage( 'criteria_not_after' )->escaped() .
@@ -562,7 +562,7 @@ class TemplateManageAchievements {
 			$HTML .= "
 				" . (
 					isset( $form['errors']['achievement_id'] ) ?
-						'<span class="error">' . $form['errors']['achievement_id'] . '</span><br/>' : '' ) . "
+						'<span class="error">' . htmlspecialchars( $form['errors']['achievement_id'], ENT_QUOTES ) . '</span><br/>' : '' ) . "
 				<select id='achievement_id' name='achievement_id'>\n";
 			foreach ( $achievements as $key => $achievement ) {
 				$achievementId = $achievement->getId();

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -174,7 +174,11 @@ class TemplateManageAchievements {
 				method='post'
 				action='{$achievementsURL}/admin?do=save'>
 				<fieldset>
-					" . ( isset( $errors['name'] ) ? '<span class="error">' . htmlspecialchars( $errors['name'], ENT_QUOTES ) . '</span>' : '' ) . "
+					" . (
+						isset( $errors['name'] ) ?
+							'<span class="error">' . htmlspecialchars( $errors['name'], ENT_QUOTES ) . '</span>' :
+							''
+					) . "
 					<label for='name' class='label_above'>" .
 						wfMessage( 'achievement_name' )->escaped() .
 					"</label>
@@ -201,8 +205,8 @@ class TemplateManageAchievements {
 						value='" . htmlentities( $achievement->getDescription(), ENT_QUOTES ) . "' />
 
 					" . ( isset( $errors['category'] ) ?
-				'<span class="error">' . htmlspecialchars( $errors['category'], ENT_QUOTES ) . '</span>' :
-				'' ) . "
+						'<span class="error">' . htmlspecialchars( $errors['category'], ENT_QUOTES ) . '</span>' :
+						'' ) . "
 					<label for='category' class='label_above'>" .
 						 wfMessage( 'achievement_category' )->escaped() .
 					 "</label>
@@ -229,26 +233,34 @@ class TemplateManageAchievements {
 
 		}
 
-		$HTML .= ( isset( $errors['image'] ) ? '<span class="error">' . htmlspecialchars( $errors['image'], ENT_QUOTES ) . '</span>' : '' ) . "
+		$HTML .= (
+				isset( $errors['image'] ) ?
+					'<span class="error">' . htmlspecialchars( $errors['image'], ENT_QUOTES ) . '</span>' :
+					''
+			) . "
 			<div id='image_upload'>
 				<img id='image_loading' src='" . MediaWikiServices::getInstance()->getUrlUtils()->expand(
 					$wgExtensionAssetsPath . "/Cheevos/images/loading.gif"
-			) . "'/>
+				) . "'/>
 				<p class='image_hint'>" . wfMessage( 'image_hint' )->escaped() . "</p>
 			</div>
 			<label for='image' class='label_above'>"
-				 . wfMessage( 'achievement_image' )->escaped() .
-				 "<div class='helper_mark'><span>" . wfMessage( 'image_upload_help' ) . "</span></div></label>
+				. wfMessage( 'achievement_image' )->escaped() .
+				"<div class='helper_mark'><span>" . wfMessage( 'image_upload_help' ) . "</span></div></label>
 			<input
-			id='image'
-			name='image'
-			type='text'
-			value='" . htmlentities( $achievement->getImage(), ENT_QUOTES ) . "' />
+				id='image'
+				name='image'
+				type='text'
+				value='" . htmlentities( $achievement->getImage(), ENT_QUOTES ) . "' />
 
-			" . ( isset( $errors['points'] ) ? '<span class="error">' . htmlspecialchars( $errors['points'], ENT_QUOTES ) . '</span>' : '' ) . "
+			" . (
+				isset( $errors['points'] ) ?
+					'<span class="error">' . htmlspecialchars( $errors['points'], ENT_QUOTES ) . '</span>' :
+					''
+			) . "
 			<label for='points' class='label_above'>" .
-				 wfMessage( 'achievement_points' )->escaped() .
-				 "<div class='helper_mark'><span>" . wfMessage( 'points_help' ) . "</span></div></label>
+				wfMessage( 'achievement_points' )->escaped() .
+				"<div class='helper_mark'><span>" . wfMessage( 'points_help' ) . "</span></div></label>
 			<input
 				id='points'
 				name='points'
@@ -353,11 +365,16 @@ class TemplateManageAchievements {
 					 (
 						 isset( $criteria['streak_reset_to_zero'] ) &&
 						 $criteria['streak_reset_to_zero'] ? "selected" : ''
-					 ) . ">True</option>
+				 ) . ">True</option>
 				</select>
 
-				" . ( isset( $errors['date_range_start'] ) ? '<span class="error">' . htmlspecialchars( $errors['date_range_start'], ENT_QUOTES ) .
-															 '</span>' : '' ) . "
+				" . (
+					isset( $errors['date_range_start'] ) ?
+						'<span class="error">' .
+						htmlspecialchars( $errors['date_range_start'], ENT_QUOTES ) .
+						'</span>' :
+						''
+				) . "
 				<label for='date_range_start' class='label_above'>" .
 					 wfMessage( 'criteria_not_before' )->escaped() . "</label>
 				<input id='date_range_start_datepicker' data-input='date_range_start' type='text' value='" .
@@ -562,7 +579,11 @@ class TemplateManageAchievements {
 			$HTML .= "
 				" . (
 					isset( $form['errors']['achievement_id'] ) ?
-						'<span class="error">' . htmlspecialchars( $form['errors']['achievement_id'], ENT_QUOTES ) . '</span><br/>' : '' ) . "
+						'<span class="error">' .
+						htmlspecialchars( $form['errors']['achievement_id'], ENT_QUOTES ) .
+						'</span><br/>' :
+						''
+				) . "
 				<select id='achievement_id' name='achievement_id'>\n";
 			foreach ( $achievements as $key => $achievement ) {
 				$achievementId = $achievement->getId();

--- a/src/Templates/TemplateManageAchievements.php
+++ b/src/Templates/TemplateManageAchievements.php
@@ -205,8 +205,8 @@ class TemplateManageAchievements {
 						value='" . htmlentities( $achievement->getDescription(), ENT_QUOTES ) . "' />
 
 					" . ( isset( $errors['category'] ) ?
-						'<span class="error">' . htmlspecialchars( $errors['category'], ENT_QUOTES ) . '</span>' :
-						'' ) . "
+				'<span class="error">' . htmlspecialchars( $errors['category'], ENT_QUOTES ) . '</span>' :
+				'' ) . "
 					<label for='category' class='label_above'>" .
 						 wfMessage( 'achievement_category' )->escaped() .
 					 "</label>
@@ -241,17 +241,17 @@ class TemplateManageAchievements {
 			<div id='image_upload'>
 				<img id='image_loading' src='" . MediaWikiServices::getInstance()->getUrlUtils()->expand(
 					$wgExtensionAssetsPath . "/Cheevos/images/loading.gif"
-				) . "'/>
+			) . "'/>
 				<p class='image_hint'>" . wfMessage( 'image_hint' )->escaped() . "</p>
 			</div>
 			<label for='image' class='label_above'>"
 				. wfMessage( 'achievement_image' )->escaped() .
 				"<div class='helper_mark'><span>" . wfMessage( 'image_upload_help' ) . "</span></div></label>
 			<input
-				id='image'
-				name='image'
-				type='text'
-				value='" . htmlentities( $achievement->getImage(), ENT_QUOTES ) . "' />
+			id='image'
+			name='image'
+			type='text'
+			value='" . htmlentities( $achievement->getImage(), ENT_QUOTES ) . "' />
 
 			" . (
 				isset( $errors['points'] ) ?


### PR DESCRIPTION
Ticket: https://fandom.atlassian.net/browse/CTOOLS-2371

This pull request focuses on improving the security and reliability of how user-generated content is handled and displayed, particularly in achievement management forms and previews. The main changes include consistently escaping or sanitizing user input to prevent XSS vulnerabilities and ensuring that dynamic HTML updates use safer methods.

**Security and Output Escaping Improvements:**

* All error messages displayed in the achievement management forms are now properly escaped using `htmlspecialchars` to prevent XSS attacks, instead of relying on potentially unsafe raw output. (`src/Templates/TemplateManageAchievements.php`) [[1]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L177-R181) [[2]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L190-R194) [[3]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L204-R208) [[4]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L232-R240) [[5]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L248-R260) [[6]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L359-R377) [[7]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L379-R396) [[8]](diffhunk://#diff-8e0c20a5a3053a8e3e06011355b0299cb6e3ff5016f8274846fd23dcfc94df80L565-R586)
* Error messages in `achievementsSave` now use the `.text()` method instead of `.escaped()` to ensure proper escaping before being passed to the template, which now handles escaping explicitly. (`src/Specials/SpecialManageAchievements.php`) [[1]](diffhunk://#diff-6b58d6dcefc3514b1250b525d3a896474a47d5681635a570fdc5910845db09efL237-R244) [[2]](diffhunk://#diff-6b58d6dcefc3514b1250b525d3a896474a47d5681635a570fdc5910845db09efL290-R290)

**JavaScript DOM Manipulation Safety:**

* Replaced `.html()` with `.text()` in all jQuery DOM updates for achievement previews, ensuring that user input is inserted as plain text rather than parsed as HTML, mitigating XSS risks. (`js/cheevos.js`) [[1]](diffhunk://#diff-7e708631d9c822a1dc88b3c27db632547b281d6c00a557b8401ac5ce079f73ceL64-R68) [[2]](diffhunk://#diff-7e708631d9c822a1dc88b3c27db632547b281d6c00a557b8401ac5ce079f73ceL78-R88)
* When dynamically creating label elements for achievements, used `document.createTextNode` instead of raw strings to safely insert achievement names. (`js/cheevos.js`)

**Code Cleanliness:**

* Removed a redundant comment regarding template escaping in the award form, as proper escaping is now enforced throughout the codebase. (`src/Specials/SpecialManageAchievements.php`)